### PR TITLE
Add link to signingbee.xyz to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Signing Bee
-ASL learning game site with gesture recognition.
+ASL learning platform incorporating real-time gesture recognition.
+<br>
+[<b>signingbee.xyz</b>](signingbee.xyz)
 
 PFW Fall 2025
 <br>


### PR DESCRIPTION
Add link to signingbee.xyz to the top of the readme to make it easier for visitors to navigate to the production site